### PR TITLE
Fix UAF bug

### DIFF
--- a/src/tairhash.c
+++ b/src/tairhash.c
@@ -374,6 +374,7 @@ int delEmptyTairHashIfNeeded(RedisModuleCtx *ctx, RedisModuleKey *key, RedisModu
                    https://github.com/redis/redis/pull/8097 
                    https://github.com/redis/redis/pull/7037
      */
+    RedisModule_CloseKey(key);
     RedisModuleCtx *ctx2 = RedisModule_GetThreadSafeContext(NULL);
     RedisModule_SelectDb(ctx2, RedisModule_GetSelectedDb(ctx));
     RedisModuleCallReply *reply = RedisModule_Call(ctx2, "DEL", "s!", raw_key);
@@ -541,7 +542,6 @@ void activeExpireTimerHandler(RedisModuleCtx *ctx, void *data) {
             }
 
             tair_hash_obj = RedisModule_ModuleTypeGetValue(real_key);
-            RedisModule_CloseKey(real_key);
 
             zsl_len = tair_hash_obj->expire_index->length;
             MY_Assert(zsl_len > 0);

--- a/src/tairhash.c
+++ b/src/tairhash.c
@@ -508,6 +508,7 @@ void activeExpireTimerHandler(RedisModuleCtx *ctx, void *data) {
                                 m_listAddNodeTail(keys, key);
                             }
                         }
+                        RedisModule_CloseKey(real_key);
                     }
                     break;
                 }
@@ -540,6 +541,7 @@ void activeExpireTimerHandler(RedisModuleCtx *ctx, void *data) {
             }
 
             tair_hash_obj = RedisModule_ModuleTypeGetValue(real_key);
+            RedisModule_CloseKey(real_key);
 
             zsl_len = tair_hash_obj->expire_index->length;
             MY_Assert(zsl_len > 0);


### PR DESCRIPTION
1、in `activeExpireTimerHandler` we `RedisModule_OpenKey`  key
2、maybe we delete a empty key: RedisModule_Call(ctx2, "DEL", "s!", key);
3、when `activeExpireTimerHandler`  exit autoMemory will Call `RedisModule_CloseKey(key)`, but now key has freed.