### PR TITLE
Support GT version param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         cd redis
         ./runtest --stack-logging --single unit/type/tairhash
 
-  test-ubuntu-with-redis-unstable-sort-mode:
+  test-ubuntu-with-redis-7:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -67,7 +67,34 @@ jobs:
        sudo apt-get install git
        git clone https://github.com/redis/redis
        cd redis
-       git checkout unstable
+       git checkout 7.0
+       make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
+    - name: make tairhash
+      run: |
+       mkdir build
+       cd build
+       cmake ../
+       make 
+    - name: test
+      run: |
+        sudo apt-get install tcl8.6 tclx
+        work_path=$(pwd)
+        module_path=$work_path/lib
+        sed -e "s#your_path#$module_path#g" tests/tairhash.tcl > redis/tests/unit/type/tairhash.tcl
+        sed -i 's#unit/type/string#unit/type/tairhash#g' redis/tests/test_helper.tcl
+        cd redis
+        ./runtest --stack-logging --single unit/type/tairhash
+
+  test-ubuntu-with-redis-7-sort-mode:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: clone and make redis
+      run: |
+       sudo apt-get install git
+       git clone https://github.com/redis/redis
+       cd redis
+       git checkout 7.0
        make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: make tairhash
       run: |

--- a/CMDDOC-CN.md
+++ b/CMDDOC-CN.md
@@ -7,7 +7,7 @@
 语法及复杂度：
 
 
-> EXHSET key field value [EX time] [EXAT time] [PX time] [PXAT time] [NX/XX] [VER/ABS version] [KEEPTTL]  
+> EXHSET key field value [EX time] [EXAT time] [PX time] [PXAT time] [NX/XX] [VER/ABS/GT version] [KEEPTTL]  
 > 时间复杂度：O(1)
 
 
@@ -15,7 +15,7 @@
 命令描述：
 
 
-> 向key指定的TairHash中插入一个field，如果TairHash不存在则自动创建一个，如果field已经存在则覆盖其值。在插入的时候，可以使用EX/EXAT/PX/PXAT给field设置过期时间，当field过期后会被主动（active expire）或被动（passivity expire）删除掉。如果指定了NX选项，则只有在field不存在的时候才会插入成功，同理，如果指定了XX选项，则只有在field存在的时候才能插入成功。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以插入成功，如果field不存在或者field当前版本为0则不进行检查，总是可以插入成功。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功, ABS指定的版本号不能为0。该命令会触发对field的被动淘汰检查
+> 向key指定的TairHash中插入一个field，如果TairHash不存在则自动创建一个，如果field已经存在则覆盖其值。在插入的时候，可以使用EX/EXAT/PX/PXAT给field设置过期时间，当field过期后会被主动（active expire）或被动（passivity expire）删除掉。如果指定了NX选项，则只有在field不存在的时候才会插入成功，同理，如果指定了XX选项，则只有在field存在的时候才能插入成功。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以插入成功，如果field不存在或者field当前版本为0则不进行检查，总是可以插入成功。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 
@@ -30,7 +30,7 @@
 > PX: 指定field的相对过期时间，单位为毫秒，0表示立刻过期
 > PXAT: 指定field的绝对过期时间，单位为毫秒 ，0表示立刻过期
 > NX/XX: NX表示当要插入的field不存在的时候才允许插入，XX表示只有当field存在的时候才允许插入  
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号    
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0  
 > KEEPTTL: 当未指定EX/EXAT/PX/PXAT时保留field的过期时间
 
 返回值：
@@ -116,7 +116,7 @@
 语法及复杂度：
 
 
-> EXHPEXPIREAT key field milliseconds-timestamp [VER/ABS version]   
+> EXHPEXPIREAT key field milliseconds-timestamp [VER/ABS/GT version]   
 > 时间复杂度：O(1)  
 
 
@@ -124,7 +124,7 @@
 命令描述：
 
 
-> 在key指定的TairHash中为一个field设置绝对过期时间，单位为毫秒。当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，注意版本号不能为0。该命令会触发对field的被动淘汰检查  
+> 在key指定的TairHash中为一个field设置绝对过期时间，单位为毫秒。当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 
@@ -134,7 +134,7 @@
 > key: 用于查找该TairHash的键    
 > field: TairHash中的一个元素    
 > milliseconds-timestamp: 以毫秒为单位的时间戳，0表示立刻过期   
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号    
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 返回值：
@@ -151,7 +151,7 @@
 语法及复杂度：
 
 
-> EXHPEXPIRE key field milliseconds [VER/ABS version]  
+> EXHPEXPIRE key field milliseconds [VER/ABS/GT version]  
 > 时间复杂度：O(1)  
 
 
@@ -159,9 +159,7 @@
 命令描述：
 
 
-> 在key指定的TairHash中为一个field设置相对过期时间，单位为毫秒。当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，注意版本号不能为0。该命令会触发对field的被动淘汰  
-
-
+> 在key指定的TairHash中为一个field设置相对过期时间，单位为毫秒。当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 参数：
 
@@ -169,7 +167,7 @@
 > key: 用于查找该TairHash的键    
 > field: TairHash中的一个元素    
 > milliseconds: 以毫秒为单位的过期时间，0表示立刻过期       
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号    
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 返回值：
@@ -186,7 +184,7 @@
 语法及复杂度：
 
 
-> EXHEXPIREAT key field timestamp [VER/ABS version]  
+> EXHEXPIREAT key field timestamp [VER/ABS/GT version]  
 > 时间复杂度：O(1)  
 
 
@@ -194,7 +192,7 @@
 命令描述：
 
 
-> 在key指定的TairHash中为一个field设置绝对过期时间，单位为秒，当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，注意版本号不能为0。该命令会触发对field的被动淘汰  
+> 在key指定的TairHash中为一个field设置绝对过期时间，单位为秒，当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 参数：
 
@@ -202,7 +200,7 @@
 > key: 用于查找该TairHash的键  
 > field: TairHash中的一个元素  
 > timestamp: 以秒为单位的时间戳，0表示立刻过期   
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号  
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 
@@ -220,7 +218,7 @@
 语法及复杂度：
 
 
-> EXHEXPIRE key field seconds [VER/ABS version]  
+> EXHEXPIRE key field seconds [VER/ABS/GT version]  
 > 时间复杂度：O(1)  
 
 
@@ -228,7 +226,7 @@
 命令描述：
 
 
-> 在key指定的TairHash中为一个field设置相对过期时间，单位为秒，当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，注意版本号不能为0。该命令会触发对field的被动淘汰  
+> 在key指定的TairHash中为一个field设置相对过期时间，单位为秒，当过期时间到时，该field会被主动删除。如果field不存在则直接返回0。如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以插入成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 
@@ -238,7 +236,7 @@
 > key: 用于查找该TairHash的键  
 > field: TairHash中的一个元素  
 > seconds: 以秒为单位的过期时间，0表示立刻过期     
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号  
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 
 
 
@@ -424,7 +422,7 @@
 语法及复杂度：
 
 
-> EXHINCRBY key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS version] [MIN minval] [MAX maxval] [KEEPTTL]    
+> EXHINCRBY key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS/GT version] [MIN minval] [MAX maxval] [KEEPTTL]    
 > 时间复杂度：O(1)  
 
 
@@ -433,7 +431,7 @@
 
 
 > 将key指定的TairHash中一个field的值加上整数value。如果TairHash不存在则自动新创建一个，如果指定的field不存在，则在加之前先将field的值初始化为0。同时还可以使用EX/EXAT/PX/PXAT为field设置过期时间。  
-> 如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以设置成功，同时将field当前版本号设置为ABS指定的版本号，注意ABS指定的版本号不能为0。MIN/MAX用户给field提供一个边界，只有本次incr操作后field的值还在此边界时incr才会被执行，否则返回overflow的错误。该命令会触发对field的被动淘汰检查  
+> 如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以设置成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0，MIN/MAX用户给field提供一个边界，只有本次incr操作后field的值还在此边界时incr才会被执行，否则返回overflow的错误
 
 
 
@@ -447,7 +445,7 @@
 > EXAT: 指定field的绝对过期时间，单位为秒 ，0表示立刻过期
 > PX: 指定field的相对过期时间，单位为毫秒，0表示立刻过期
 > PXAT: 指定field的绝对过期时间，单位为毫秒，0表示立刻过期
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号  
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 > MAX/MIN: 设置最大最小边界，本次incr操作后，field的值在此边界时incr才会被执行，否则返回overflow的错误。
 > KEEPTTL: 当未指定EX/EXAT/PX/PXAT时保留field的过期时间
 
@@ -465,7 +463,7 @@
 语法及复杂度：
 
 
-> EXHINCRBYFLOAT key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS version] [MIN minval] [MAX maxval] [KEEPTTL]   
+> EXHINCRBYFLOAT key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS/GT version] [MIN minval] [MAX maxval] [KEEPTTL]   
 > 时间复杂度：O(1)  
 
 
@@ -474,7 +472,7 @@
 
 
 > 将key指定的TairHash中一个field的值加上浮点型value。如果TairHash不存在则自动新创建一个，如果指定的field不存在，则在加之前先将field的值初始化为0。同时还可以使用EX/EXAT/PX/PXAT为field设置过期时间。  
-> 如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以设置成功，同时将field当前版本号设置为ABS指定的版本号，注意ABS指定的版本号不能为0。MIN/MAX用户给field提供一个边界，只有本次incr操作后field的值还在此边界时incr才会被执行，否则返回overflow的错误。该命令会触发对field的被动淘汰检查  
+> 如果指定了VER参数，则VER所携带的版本号必须和field当前版本号一致才可以设置成功，或者如果VER参数所携带的版本号为0，则不进行版本校验。ABS参数用于强制给field设置版本号，而不管field当前的版本号，总是可以设置成功，同时将field当前版本号设置为ABS指定的版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0，MIN/MAX用户给field提供一个边界，只有本次incr操作后field的值还在此边界时incr才会被执行，否则返回overflow的错误
 
 
 
@@ -488,7 +486,7 @@
 > EXAT: 指定field的绝对过期时间，单位为秒，0表示立刻过期
 > PX: 指定field的相对过期时间，单位为毫秒，0表示立刻过期
 > PXAT: 指定field的绝对过期时间，单位为毫秒，0表示立刻过期
-> VER/ABS: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号  
+> VER/ABS/GT: VER表示只有指定的版本和field当前的版本一致时才允许设置，如果VER指定的版本为0则表示不进行版本检查，ABS表示无论field当前的版本是多少都强制设置并修改版本号，GT表示只有指定的版本大于当前版本时才允许设置，ABS和GT指定的版本号不能为0
 > MAX/MIN: 设置最大最小边界，本次incr操作后，field的值在此边界时incr才会被执行，否则返回overflow的错误。
 > KEEPTTL: 当未指定EX/EXAT/PX/PXAT时保留field的过期时间
 

--- a/CMDDOC.md
+++ b/CMDDOC.md
@@ -6,11 +6,11 @@
 Grammar and complexity：
 
 
-> EXHSET key field value [EX time] [EXAT time] [PX time] [PXAT time] [NX/XX] [VER/ABS version] [KEEPTTL]   
+> EXHSET key field value [EX time] [EXAT time] [PX time] [PXAT time] [NX/XX] [VER/ABS/GT version] [KEEPTTL]   
 > time complexity：O(1)   
 
 Command Description：  
-> Insert a field into the TairHash specified by the key. If TairHash does not exist, it will automatically create one, and if the field already exists, its value will be overwritten. When inserting, you can use EX/EXAT/PX/PXAT to set the expiration time for the field. When the field expires, it will be deleted actively (active expire) or passive (passivity expire). If the NX option is specified, the insertion will be successful only when the field does not exist. Similarly, if the XX option is specified, the insertion will be successful only when the field exists. If the VER parameter is specified, the version number carried by the VER must be consistent with the current version number of the field before it can be inserted successfully. If the field does not exist or the current version of the field is 0, no check is performed, and the insertion can always be successful. The ABS parameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be inserted successfully, and the version number specified by ABS cannot be 0. This command will trigger the passive elimination check of the field 
+> Insert a field into the TairHash specified by the key. If TairHash does not exist, it will automatically create one, and if the field already exists, its value will be overwritten. When inserting, you can use EX/EXAT/PX/PXAT to set the expiration time for the field. When the field expires, it will be deleted actively (active expire) or passive (passivity expire). If the NX option is specified, the insertion will be successful only when the field does not exist. Similarly, if the XX option is specified, the insertion will be successful only when the field exists. If the VER parameter is specified, the version number carried by the VER must be consistent with the current version number of the field before it can be inserted successfully. If the field does not exist or the current version of the field is 0, no check is performed, and the insertion can always be successful. The ABS parameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be inserted successfully, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. This command will trigger the passive elimination check of the field 
 
 
 parameter：
@@ -23,7 +23,8 @@ parameter：
 > PX: The relative expiration time of the specified field, in milliseconds, 0 means expire immediately   
 > PXAT: Specify the absolute expiration time of the field, in milliseconds, 0 means expire immediately   
 > NX/XX: NX means inserting is allowed only when the field to be inserted does not exist, XX means inserting is allowed only when the field exists   
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field   
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
+    
 > KEEPTTL: Retain the time to live associated with the field. KEEPTTL cannot be used together with EX/EXAT/PX/PXAT  
 
 Return：
@@ -103,7 +104,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHPEXPIREAT key field milliseconds-timestamp [VER/ABS version]   
+> EXHPEXPIREAT key field milliseconds-timestamp [VER/ABS/GT version]   
 > time complexity: (1)     
 
 
@@ -111,7 +112,7 @@ Grammar and complexity：
 Command Description：
 
 
-> Set the absolute expiration time for a field in the TaiHash specified by the key, in milliseconds. When the expiration time is up, the field will be deleted actively. If the field does not exist, return 0 directly. If VERParameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number cannot be 0. This command will trigger the passive elimination check of the field
+> Set the absolute expiration time for a field in the TaiHash specified by the key, in milliseconds. When the expiration time is up, the field will be deleted actively. If the field does not exist, return 0 directly. If VER parameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. This command will trigger the passive elimination check of the field
 
 
 
@@ -121,7 +122,7 @@ Parameter：
 > key: The key used to find the TairHash   
 > field: An element in TairHash   
 > milliseconds-timestamp: Timestamp in milliseconds, 0 means expire immediately   
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field.     
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 
 
 Return：
@@ -138,7 +139,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHPEXPIRE key field milliseconds [VER/ABS version]    
+> EXHPEXPIRE key field milliseconds [VER/ABS/GT version]    
 > time complexity：O(1)  
 
 
@@ -146,7 +147,7 @@ Grammar and complexity：
 Command Description：
 
 
-> Set the relative expiration time for a field in the TairHash specified by the key, in milliseconds. When the expiration time is up, the field will be deleted actively. If the field does not exist, return 0 directly. If VERParameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number cannot be 0. This command will trigger the passive elimination of the field   
+> Set the relative expiration time for a field in the TairHash specified by the key, in milliseconds. When the expiration time is up, the field will be deleted actively. If the field does not exist, return 0 directly. If VER parameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. This command will trigger the passive elimination of the field   
 
 
 
@@ -156,8 +157,7 @@ Parameter：
 > key: The key used to find the TairHash   
 > field: An element in TairHash      
 > milliseconds: Expiration time in milliseconds, 0 means expire immediately   
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field.   
-
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 
 
 
@@ -175,7 +175,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHEXPIREAT key field timestamp [VER/ABS version]   
+> EXHEXPIREAT key field timestamp [VER/ABS/GT version]   
 > time complexity：O(1)     
 
 
@@ -183,7 +183,7 @@ Grammar and complexity：
 Command Description：
 
 
-> Set the absolute expiration time for a field in the TairHash specified by the key, in seconds. When the expiration time expires, the field will be actively deleted. If the field does not exist, return 0 directly. If VERParameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number cannot be 0. This command will trigger the passive elimination of the field  
+> Set the absolute expiration time for a field in the TairHash specified by the key, in seconds. When the expiration time expires, the field will be actively deleted. If the field does not exist, return 0 directly. If VER parameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. This command will trigger the passive elimination of the field  
 
 Parameter：
 
@@ -191,7 +191,7 @@ Parameter：
 > key: The key used to find the TairHash   
 > field: An element in TairHash    
 > timestamp: Timestamp in seconds，0 means expire immediately    
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field.
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 
 
 
@@ -209,7 +209,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHEXPIRE key field seconds [VER/ABS version]     
+> EXHEXPIRE key field seconds [VER/ABS/GT version]     
 > time complexity：O(1)     
 
 
@@ -217,7 +217,7 @@ Grammar and complexity：
 Command Description：
 
 
-> Set the relative expiration time for a field in the TairHash specified by the key, in seconds. When the expiration time expires, the field will be actively deleted. If the field does not exist, return 0 directly. If VERParameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number cannot be 0. This command will trigger the passive elimination of the field
+> Set the relative expiration time for a field in the TairHash specified by the key, in seconds. When the expiration time expires, the field will be actively deleted. If the field does not exist, return 0 directly. If VER parameter is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to force the field to set the version number, regardless of the current version number of the field, it can always be inserted successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. This command will trigger the passive elimination of the field
 
 
 
@@ -227,7 +227,7 @@ Parameter：
 > key: The key used to find the TairHash   
 > field: An element in TairHash   
 > timestamp: Timestamp in seconds, 0 means expire immediately    
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field.   
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 
 
 
@@ -408,7 +408,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHINCRBY key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS version] [MIN minval] [MAX maxval] [KEEPTTL]    
+> EXHINCRBY key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS/GT version] [MIN minval] [MAX maxval] [KEEPTTL]    
 > time complexity：O(1)     
 
 
@@ -417,7 +417,7 @@ Command Description：
 
 
 > Add the integer value to the value of a field in TairHash specified by key. If TairHash does not exist, it will automatically create a new one. If the specified field does not exist, initialize the value of the field to 0 before adding it. At the same time, you can also use EX/EXAT/PX/PXAT to set the expiration time for the field        
-> If VER is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be set successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number specified by ABS cannot be 0. MIN/MAX users provide a boundary for the field. Incr will be executed only when the value of the field is still on this boundary after this incr operation, otherwise an overflow error will be returned. This command will trigger the passive elimination check of the field   
+> If VER is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be set successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. MIN/MAX users provide a boundary for the field. Incr will be executed only when the value of the field is still on this boundary after this incr operation, otherwise an overflow error will be returned. This command will trigger the passive elimination check of the field   
 
 
 
@@ -431,7 +431,7 @@ Parameter：
 > EXAT: Specify the absolute expiration time of the field, in seconds, 0 means expire immediately   
 > PX: The relative expiration time of the specified field, in milliseconds, 0 means expire immediately  
 > PXAT: Specify the absolute expiration time of the field, in milliseconds, 0 means expire immediately  
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field  
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 > MAX/MIN: Specify the boundary, incr will be executed only when the value of the field is still on this boundary after this incr operation,otherwise an overflow error will be returned   
 > KEEPTTL: Retain the time to live associated with the field. KEEPTTL cannot be used together with EX/EXAT/PX/PXAT
 
@@ -450,7 +450,7 @@ Return：
 Grammar and complexity：
 
 
-> EXHINCRBYFLOAT key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS version] [MIN minval] [MAX maxval] [KEEPTTL]    
+> EXHINCRBYFLOAT key field value [EX time] [EXAT time] [PX time] [PXAT time] [VER/ABS/GT version] [MIN minval] [MAX maxval] [KEEPTTL]    
 > time complexity：O(1)     
 
 
@@ -459,7 +459,7 @@ Command Description：
 
 
 > Add the floating-point value to the value of a field in TairHash specified by key. If TairHash does not exist, it will automatically create a new one. If the specified field does not exist, initialize the value of the field to 0 before adding it. At the same time, you can also use EX/EXAT/PX/PXAT to set the expiration time for the field   
-> If VER is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VERParameter is 0, no version verification is performed. ABSParameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be set successfully. At the same time, the current version number of the field is set to the version number specified by ABS. Note that the version number specified by ABS cannot be 0. MIN/MAX users provide a boundary for the field. Incr will be executed only when the value of the field is still on this boundary after this incr operation, otherwise an overflow error will be returned. This command will trigger the passive elimination check of the field  
+> If VER is specified, the version number carried by VER must be consistent with the current version number of the field before it can be set successfully, or if the version number carried by VER parameter is 0, no version verification is performed. ABS parameter is used to forcibly set the version number for the field, regardless of the current version number of the field, it can always be set successfully. At the same time, the current version number of the field is set to the version number specified by ABS, GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0. MIN/MAX users provide a boundary for the field. Incr will be executed only when the value of the field is still on this boundary after this incr operation, otherwise an overflow error will be returned. This command will trigger the passive elimination check of the field  
 
 
 
@@ -473,7 +473,7 @@ Parameter：
 > EXAT: Specify the absolute expiration time of the field, in seconds, 0 means expire immediately  
 > PX: The relative expiration time of the specified field, in milliseconds, 0 means expire immediately  
 > PXAT: Specify the absolute expiration time of the field, in milliseconds, 0 means expire immediately  
-> VER/ABS: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field  
+> VER/ABS/GT: VER means that the setting is allowed only when the specified version is consistent with the current version of the field. If the version specified by VER is 0, it means that no version check will be performed. ABS means that the version number is forced to be set and modified regardless of the current version of the field., GT means that the setting is only allowed when the specified version is greater than the current version of the field, the version specified by GT and ABS cannot be 0.
 > MAX/MIN: Specify the boundary, incr will be executed only when the value of the field is still on this boundary after this incr operation,otherwise an overflow error will be returned   
 > KEEPTTL: Retain the time to live associated with the field. KEEPTTL cannot be used together with EX/EXAT/PX/PXAT
 

--- a/src/tairhash.c
+++ b/src/tairhash.c
@@ -966,7 +966,7 @@ int tairHashExpireGenericFunc(RedisModuleCtx *ctx, RedisModuleString **argv, int
         return REDISMODULE_ERR;
     }
 
-    if (version < 0 || ((ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && version == 0)) {
+    if (version < 0 || ((ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) && version == 0)) {
         RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_SYNTAX);
         return REDISMODULE_ERR;
     }
@@ -1213,7 +1213,7 @@ int TairHashTypeHset_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         return REDISMODULE_ERR;
     }
 
-    if (version < 0 || ((ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && version == 0)) {
+    if (version < 0 || ((ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) && version == 0)) {
         RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_SYNTAX);
         return REDISMODULE_ERR;
     }
@@ -1832,7 +1832,7 @@ int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
         return REDISMODULE_ERR;
     }
 
-    if (version < 0 || ((ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && version == 0)) {
+    if (version < 0 || ((ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) && version == 0)) {
         RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_SYNTAX);
         return REDISMODULE_ERR;
     }
@@ -2062,7 +2062,7 @@ int TairHashTypeHincrByFloat_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
         return REDISMODULE_ERR;
     }
 
-    if (version < 0 || ((ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && version == 0)) {
+    if (version < 0 || ((ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) && version == 0)) {
         RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_SYNTAX);
         return REDISMODULE_ERR;
     }

--- a/src/tairhash.c
+++ b/src/tairhash.c
@@ -49,8 +49,9 @@ static RedisModuleType *TairHashType;
 #define TAIR_HASH_SET_ABS_EXPIRE (1 << 4)
 #define TAIR_HASH_SET_WITH_VER (1 << 5)
 #define TAIR_HASH_SET_WITH_ABS_VER (1 << 6)
-#define TAIR_HASH_SET_WITH_BOUNDARY (1 << 7)
-#define TAIR_HASH_SET_KEEPTTL (1 << 8)
+#define TAIR_HASH_SET_WITH_GT_VER (1 << 7)
+#define TAIR_HASH_SET_WITH_BOUNDARY (1 << 8)
+#define TAIR_HASH_SET_KEEPTTL (1 << 9)
 
 #define UNIT_SECONDS 0
 #define UNIT_MILLISECONDS 1
@@ -941,12 +942,16 @@ int tairHashExpireGenericFunc(RedisModuleCtx *ctx, RedisModuleString **argv, int
     if (argc > 4) {
         for (j = 4; j < argc; j++) {
             RedisModuleString *next = (j == argc - 1) ? NULL : argv[j + 1];
-            if (!mstrcasecmp(argv[4], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+            if (!mstrcasecmp(argv[4], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
                 ex_flags |= TAIR_HASH_SET_WITH_VER;
                 version_p = next;
                 j++;
-            } else if (!mstrcasecmp(argv[4], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && next) {
+            } else if (!mstrcasecmp(argv[4], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER)  && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
                 ex_flags |= TAIR_HASH_SET_WITH_ABS_VER;
+                version_p = next;
+                j++;
+            } else if (!mstrcasecmp(argv[4], "gt") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+                ex_flags |= TAIR_HASH_SET_WITH_GT_VER;
                 version_p = next;
                 j++;
             } else {
@@ -996,9 +1001,16 @@ int tairHashExpireGenericFunc(RedisModuleCtx *ctx, RedisModuleString **argv, int
         nokey = 0;
         skey = dictGetKey(de);
         tair_hash_val = dictGetVal(de);
-        if (ex_flags & TAIR_HASH_SET_WITH_VER && version != 0 && version != tair_hash_val->version) {
-            RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
-            return REDISMODULE_ERR;
+        if (ex_flags & TAIR_HASH_SET_WITH_VER) {
+            if (version != 0 && version != tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
+        } else if (ex_flags & TAIR_HASH_SET_WITH_GT_VER) {
+            if (version <= tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
         }
 
         if (milliseconds == 0) {
@@ -1022,10 +1034,10 @@ int tairHashExpireGenericFunc(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
         RedisModule_ReplyWithLongLong(ctx, 1);
 
-        tair_hash_val->version += 1;
-
-        if (ex_flags & TAIR_HASH_SET_WITH_ABS_VER) {
+        if (ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) {
             tair_hash_val->version = version;
+        } else {
+             tair_hash_val->version += 1;
         }
 
         size_t vlen = 0, VSIZE_MAX = 5;
@@ -1119,7 +1131,7 @@ int mstring2ld(RedisModuleString *val, long double *r_val) {
 
 /* ========================= "tairhash" type commands ======================= */
 
-/* EXHSET <key> <field> <value> [EX time] [EXAT time] [PX time] [PXAT time] [NX|XX] [VER version | ABS version] [KEEPTTL] */
+/* EXHSET <key> <field> <value> [EX | EXAT | PX| PXAT time] [NX|XX] [VER version | ABS version | GT version] [KEEPTTL] */
 int TairHashTypeHset_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 
@@ -1166,12 +1178,16 @@ int TairHashTypeHset_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
             ex_flags |= TAIR_HASH_SET_ABS_EXPIRE;
             expire_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_VER;
             version_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_ABS_VER;
+            version_p = next;
+            j++;
+        } else if (!mstrcasecmp(argv[j], "gt") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+            ex_flags |= TAIR_HASH_SET_WITH_GT_VER;
             version_p = next;
             j++;
         } else if (!mstrcasecmp(argv[j], "keepttl") && !(ex_flags & TAIR_HASH_SET_EX) && !(ex_flags & TAIR_HASH_SET_PX)) {
@@ -1237,16 +1253,23 @@ int TairHashTypeHset_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         }
 
         /* Version equals 0 means no version checking */
-        if (ex_flags & TAIR_HASH_SET_WITH_VER && version != 0 && version != tair_hash_val->version) {
-            RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
-            return REDISMODULE_ERR;
+        if (ex_flags & TAIR_HASH_SET_WITH_VER) {
+            if (version != 0 && version != tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
+        } else if (ex_flags & TAIR_HASH_SET_WITH_GT_VER) {
+            if (version <= tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
         }
     }
 
-    tair_hash_val->version += 1;
-
-    if (ex_flags & TAIR_HASH_SET_WITH_ABS_VER) {
+    if (ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) {
         tair_hash_val->version = version;
+    } else {
+        tair_hash_val->version += 1;
     }
 
     if (0 < expire) {
@@ -1516,22 +1539,22 @@ int TairHashTypeHmsetWithOpts_RedisCommand(RedisModuleCtx *ctx, RedisModuleStrin
     return REDISMODULE_OK;
 }
 
-/*  EXHPEXPIREAT <key> <field> <milliseconds-timestamp> [ VER version | ABS version ]*/
+/*  EXHPEXPIREAT <key> <field> <milliseconds-timestamp> [ VER version | ABS version | GT version ]*/
 int TairHashTypeHpexpireAt_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return tairHashExpireGenericFunc(ctx, argv, argc, 0, UNIT_MILLISECONDS);
 }
 
-/*  EXHPEXPIRE <key> <field> <milliseconds> [ VER version | ABS version ]*/
+/*  EXHPEXPIRE <key> <field> <milliseconds> [ VER version | ABS version | GT version ]*/
 int TairHashTypeHpexpire_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return tairHashExpireGenericFunc(ctx, argv, argc, RedisModule_Milliseconds(), UNIT_MILLISECONDS);
 }
 
-/*  EXHEXPIREAT <key> <field> <timestamp> [ VER version | ABS version ] */
+/*  EXHEXPIREAT <key> <field> <timestamp> [ VER version | ABS version | GT version ] */
 int TairHashTypeHexpireAt_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return tairHashExpireGenericFunc(ctx, argv, argc, 0, UNIT_SECONDS);
 }
 
-/*  EXHEXPIRE <key> <field> <seconds> [ VER version | ABS version ] */
+/*  EXHEXPIRE <key> <field> <seconds> [ VER version | ABS version | GT version ] */
 int TairHashTypeHexpire_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return tairHashExpireGenericFunc(ctx, argv, argc, RedisModule_Milliseconds(), UNIT_SECONDS);
 }
@@ -1716,7 +1739,7 @@ int TairHashTypeHsetVer_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
     return REDISMODULE_OK;
 }
 
-/* EXHINCRBY <key> <field> <value> [EX time] [EXAT time] [PX time] [PXAT time] [VER version | ABS version] [MIN minval] [MAX maxval] [KEEPTTL] */
+/* EXHINCRBY <key> <field> <value> [EX time] [EXAT time] [PX time] [PXAT time] [VER version | ABS version | GT version] [MIN minval] [MAX maxval] [KEEPTTL] */
 int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 
@@ -1766,12 +1789,16 @@ int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
             ex_flags |= TAIR_HASH_SET_ABS_EXPIRE;
             expire_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER)  && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_VER;
             version_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_ABS_VER;
+            version_p = next;
+            j++;
+         } else if (!mstrcasecmp(argv[j], "gt") && !(ex_flags & TAIR_HASH_SET_WITH_VER)  && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+            ex_flags |= TAIR_HASH_SET_WITH_GT_VER;
             version_p = next;
             j++;
         } else if (!mstrcasecmp(argv[j], "min") && next) {
@@ -1862,9 +1889,16 @@ int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
         }
 
         /* Version equals 0 means no version checking */
-        if (ex_flags & TAIR_HASH_SET_WITH_VER && version != 0 && version != tair_hash_val->version) {
-            RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
-            return REDISMODULE_ERR;
+        if (ex_flags & TAIR_HASH_SET_WITH_VER) {
+            if (version != 0 && version != tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            } 
+        } else if (ex_flags & TAIR_HASH_SET_WITH_GT_VER) {
+            if (version <= tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
         }
     }
 
@@ -1876,10 +1910,10 @@ int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
         return REDISMODULE_ERR;
     }
 
-    tair_hash_val->version++;
-
-    if (ex_flags & TAIR_HASH_SET_WITH_ABS_VER) {
+    if (ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) {
         tair_hash_val->version = version;
+    } else {
+        tair_hash_val->version += 1;
     }
 
     cur_val += incr;
@@ -1932,7 +1966,7 @@ int TairHashTypeHincrBy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
     return REDISMODULE_OK;
 }
 
-/* EXHINCRBYFLOAT <key> <field> <value> [EX time] [EXAT time] [PX time] [PXAT time] [VER version | ABS version] [MIN
+/* EXHINCRBYFLOAT <key> <field> <value> [EX time] [EXAT time] [PX time] [PXAT time] [VER version | ABS version | GT version] [MIN
  * minval] [MAX maxval] [KEEPTTL] */
 int TairHashTypeHincrByFloat_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
@@ -1985,12 +2019,16 @@ int TairHashTypeHincrByFloat_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
             ex_flags |= TAIR_HASH_SET_ABS_EXPIRE;
             expire_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "ver") && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER)  && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_VER;
             version_p = next;
             j++;
-        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && next) {
+        } else if (!mstrcasecmp(argv[j], "abs") && !(ex_flags & TAIR_HASH_SET_WITH_VER) && !(ex_flags & TAIR_HASH_SET_WITH_GT_VER) && next) {
             ex_flags |= TAIR_HASH_SET_WITH_ABS_VER;
+            version_p = next;
+            j++;
+        } else if (!mstrcasecmp(argv[j], "gt") && !(ex_flags & TAIR_HASH_SET_WITH_VER)  && !(ex_flags & TAIR_HASH_SET_WITH_ABS_VER) && next) {
+            ex_flags |= TAIR_HASH_SET_WITH_GT_VER;
             version_p = next;
             j++;
         } else if (!mstrcasecmp(argv[j], "min") && next) {
@@ -2086,9 +2124,16 @@ int TairHashTypeHincrByFloat_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
         }
 
         /* Version equals 0 means no version checking */
-        if (ex_flags & TAIR_HASH_SET_WITH_VER && version != 0 && version != tair_hash_val->version) {
-            RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
-            return REDISMODULE_ERR;
+        if (ex_flags & TAIR_HASH_SET_WITH_VER) {
+            if (version != 0 && version != tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
+        } else if (ex_flags & TAIR_HASH_SET_WITH_GT_VER) {
+            if (version <= tair_hash_val->version) {
+                RedisModule_ReplyWithError(ctx, TAIRHASH_ERRORMSG_VERSION);
+                return REDISMODULE_ERR;
+            }
         }
     }
 
@@ -2108,10 +2153,10 @@ int TairHashTypeHincrByFloat_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
         return REDISMODULE_ERR;
     }
 
-    tair_hash_val->version++;
-
-    if (ex_flags & TAIR_HASH_SET_WITH_ABS_VER) {
+    if (ex_flags & (TAIR_HASH_SET_WITH_ABS_VER | TAIR_HASH_SET_WITH_GT_VER)) {
         tair_hash_val->version = version;
+    } else {
+        tair_hash_val->version += 1;
     }
 
     cur_val += incr;

--- a/tests/tairhash.tcl
+++ b/tests/tairhash.tcl
@@ -1711,7 +1711,7 @@ start_server {tags {"tairhash"} overrides {bind 0.0.0.0}} {
 
         after 1000
 
-        assert_equal 1 [r exhget tairhashkey field]
+        assert_equal {} [r exhget tairhashkey field]
         assert_equal -1 [r exhver tairhashkey field]
     }
     

--- a/tests/tairhash.tcl
+++ b/tests/tairhash.tcl
@@ -1683,6 +1683,15 @@ start_server {tags {"tairhash"} overrides {bind 0.0.0.0}} {
     test {Exhash GT version} {
         r del exhashkey
 
+        catch {r exhset tairhashkey field 1 abs 10 gt 11} err
+        assert_match {*ERR*syntax*error*} $err
+
+        catch {r exhset tairhashkey field 1 ver 0 gt 11} err
+        assert_match {*ERR*syntax*error*} $err
+
+        catch {r exhset tairhashkey field 1 ver 0 abs 11} err
+        assert_match {*ERR*syntax*error*} $err
+
         assert_equal 1 [r exhset tairhashkey field 1 abs 10]
 
         catch {r exhset tairhashkey field 2 gt 9} err

--- a/tests/tairhash.tcl
+++ b/tests/tairhash.tcl
@@ -1679,6 +1679,32 @@ start_server {tags {"tairhash"} overrides {bind 0.0.0.0}} {
        $rd1 close
        $rd2 close
     }
+
+    test {Exhash GT version} {
+        r del exhashkey
+
+        assert_equal 1 [r exhset tairhashkey field 1 abs 10]
+
+        catch {r exhset tairhashkey field 2 gt 9} err
+        assert_match {*ERR*update*version*is*stale*} $err
+        assert_equal 0 [r exhset tairhashkey field 2 gt 13]
+        assert_equal 13 [r exhver  tairhashkey field]
+
+        catch {r exhincrby tairhashkey field 2 gt 13} err
+        assert_match {*ERR*update*version*is*stale*} $err
+        assert_equal 4 [r exhincrby tairhashkey field 2 gt 14]
+        assert_equal 14 [r exhver  tairhashkey field]
+
+        catch {r exhexpire tairhashkey field 1 gt 14} err
+        assert_match {*ERR*update*version*is*stale*} $err
+        assert_equal 4 [r exhexpire tairhashkey field 1 gt 20]
+        assert_equal 20 [r exhver tairhashkey field]
+
+        after 1000
+
+        assert_equal 1 [r exhget tairhashkey field]
+        assert_equal -1 [r exhver tairhashkey field]
+    }
     
     start_server {tags {"tairhash repl"} overrides {bind 0.0.0.0}} {
         r module load $testmodule

--- a/tests/tairhash.tcl
+++ b/tests/tairhash.tcl
@@ -1706,7 +1706,7 @@ start_server {tags {"tairhash"} overrides {bind 0.0.0.0}} {
 
         catch {r exhexpire tairhashkey field 1 gt 14} err
         assert_match {*ERR*update*version*is*stale*} $err
-        assert_equal 4 [r exhexpire tairhashkey field 1 gt 20]
+        assert_equal 1 [r exhexpire tairhashkey field 1 gt 20]
         assert_equal 20 [r exhver tairhashkey field]
 
         after 1000

--- a/tests/tairhash.tcl
+++ b/tests/tairhash.tcl
@@ -1692,6 +1692,12 @@ start_server {tags {"tairhash"} overrides {bind 0.0.0.0}} {
         catch {r exhset tairhashkey field 1 ver 0 abs 11} err
         assert_match {*ERR*syntax*error*} $err
 
+        catch {r exhset tairhashkey field 1 abs 0} err
+        assert_match {*ERR*syntax*error*} $err
+
+        catch {r exhset tairhashkey field 1 gt 0} err
+        assert_match {*ERR*syntax*error*} $err
+
         assert_equal 1 [r exhset tairhashkey field 1 abs 10]
 
         catch {r exhset tairhashkey field 2 gt 9} err


### PR DESCRIPTION
 issue link #26 

Support GT (Greater than) param which means the setting is only allowed when the specified version is greater than the current version of the field.