### PR TITLE
Change skiplist maxlevel from 64 to 32

### DIFF
--- a/dep/skiplist.h
+++ b/dep/skiplist.h
@@ -2,7 +2,7 @@
 
 #include "../src/redismodule.h"
 
-#define ZSKIPLIST_MAXLEVEL 64 /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
 #define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
 
 typedef struct {

--- a/dep/tairhash_skiplist.h
+++ b/dep/tairhash_skiplist.h
@@ -6,7 +6,7 @@
 #include "redismodule.h"
 #include "slab.h"
 
-#define TAIRHASH_ZSKIPLIST_MAXLEVEL 64 /* Should be enough for 2^64 elements */
+#define TAIRHASH_ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
 #define TAIRHASH_ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
 typedef struct tairhash_zskiplistNode {
     Slab *slab;


### PR DESCRIPTION
This change follows https://github.com/redis/redis/pull/6818,
which can save a lot of memory under certain cases.